### PR TITLE
Add inverse challenge to daily run for event

### DIFF
--- a/src/game-mode.ts
+++ b/src/game-mode.ts
@@ -69,6 +69,19 @@ export class GameMode implements GameModeConfig {
   }
 
   /**
+   * Enables challenges if they are disabled and sets the specified challenge's value
+   * @param challenge The challenge to set
+   * @param value The value to give the challenge. Impact depends on the specific challenge
+   */
+  setChallengeValue(challenge: Challenges, value: number) {
+    if (!this.isChallenge) {
+      this.isChallenge = true;
+      this.challenges = allChallenges.map(c => copyChallenge(c));
+    }
+    this.challenges.filter((chal: Challenge) => chal.id === challenge).map((chal: Challenge) => (chal.value = value));
+  }
+
+  /**
    * Helper function to see if a GameMode has a specific challenge type
    * @param challenge the Challenges it looks for
    * @returns true if the game mode has that challenge

--- a/src/phases/title-phase.ts
+++ b/src/phases/title-phase.ts
@@ -212,6 +212,8 @@ export class TitlePhase extends Phase {
 
       const generateDaily = (seed: string) => {
         globalScene.gameMode = getGameMode(GameModes.DAILY);
+        // Daily runs don't support all challenges yet (starter select restrictions aren't considered)
+        globalScene.eventManager.startEventChallenges();
 
         globalScene.setSeed(seed);
         globalScene.resetSeed(0);

--- a/src/timed-event-manager.ts
+++ b/src/timed-event-manager.ts
@@ -9,6 +9,7 @@ import { WeatherType } from "#enums/weather-type";
 import { CLASSIC_CANDY_FRIENDSHIP_MULTIPLIER } from "./data/balance/starters";
 import { MysteryEncounterType } from "./enums/mystery-encounter-type";
 import { MysteryEncounterTier } from "./enums/mystery-encounter-tier";
+import { Challenges } from "#enums/challenges";
 
 export enum EventType {
   SHINY,
@@ -43,6 +44,11 @@ interface EventWaveReward {
 
 type EventMusicReplacement = [string, string];
 
+interface EventChallenge {
+  challenge: Challenges;
+  value: number;
+}
+
 interface TimedEvent extends EventBanner {
   name: string;
   eventType: EventType;
@@ -61,6 +67,7 @@ interface TimedEvent extends EventBanner {
   classicWaveRewards?: EventWaveReward[]; // Rival battle rewards
   trainerShinyChance?: number; // Odds over 65536 of trainer mon generating as shiny
   music?: EventMusicReplacement[];
+  dailyRunChallenges?: EventChallenge[];
 }
 
 const timedEvents: TimedEvent[] = [
@@ -296,6 +303,12 @@ const timedEvents: TimedEvent[] = [
       ["title", "title_afd"],
       ["battle_rival_3", "battle_rival_3_afd"],
     ],
+    dailyRunChallenges: [
+      {
+        challenge: Challenges.INVERSE_BATTLE,
+        value: 1,
+      },
+    ],
   },
 ];
 
@@ -509,6 +522,16 @@ export class TimedEventManager {
       }
     });
     return ret;
+  }
+
+  /**
+   * Activates any challenges on {@linkcode globalScene.gameMode} for the currently active event
+   */
+  startEventChallenges(): void {
+    const challenges = this.activeEvent()?.dailyRunChallenges;
+    challenges?.forEach((eventChal: EventChallenge) =>
+      globalScene.gameMode.setChallengeValue(eventChal.challenge, eventChal.value),
+    );
   }
 }
 


### PR DESCRIPTION
## What are the changes the user will see?
Daily run will use inverse challenge

## Why am I making these changes?

## What are the changes from a developer perspective?
- Added `setChallengeValue` to `GameMode` to set particular challenge values after init
- Added `EventChallenge`s to timed events and a method to activate them
- Set the challenge for the April Fool's event to inverse

## Screenshots/Videos
<!--
If your changes are changing anything on the user experience, please provide visual proofs of it
Please take screenshots/videos before and after your changes, to show what is brought by this PR
-->

## How to test the changes?
<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->

## Checklist
- [ ] **I'm using `beta` as my base branch**
- [ ] There is no overlap with another PR?
- [ ] The PR is self-contained and cannot be split into smaller PRs?
- [ ] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes manually?
- [ ] Are all unit tests still passing? (`npm run test`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [ ] If so, please leave a link to it here: 
- [ ] Has the translation team been contacted for proofreading/translation?